### PR TITLE
fix unique repositories in build metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - "pip install -r requirements.txt"
   - "pip install -r tests/requirements.txt"
   - "pip install pytest-cov coveralls"
+  - "pip install git+https://github.com/DBuildService/osbs-client"
 # command to run tests
 script: "py.test -vv tests --cov atomic_reactor"
 # run in a docker container

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -69,24 +69,75 @@ class TagConf(object):
     """
 
     def __init__(self):
-        self.images = []  # list of ImageName instances
+        # list of ImageNames with predictable names
+        self._primary_images = []
+        # list if ImageName instances with unpredictable names
+        self._unique_images = []
 
-    def add_image(self, image):
+    @property
+    def primary_images(self):
         """
+        primary image names are predictable and should be used for layering
+
+        this is consumed by metadata plugin
+
+        :return: list of ImageName
+        """
+        return self._primary_images
+
+    @property
+    def images(self):
+        """
+        list of all ImageNames
+
+        :return: list of ImageName
+        """
+        return self._primary_images + self._unique_images
+
+    @property
+    def unique_images(self):
+        """
+        unique image names are unpredictable and should be used for tracking only
+
+        this is consumed by metadata plugin
+
+        :return: list of ImageName
+        """
+        return self._unique_images
+
+    def add_primary_image(self, image):
+        """
+        add new primary image
+
+        used by tag_by_labels plugin
 
         :param image: str, name of image (e.g. "namespace/httpd:2.4")
         :return: None
         """
-        self.images.append(ImageName.parse(image))
+        self._primary_images.append(ImageName.parse(image))
 
-    def add_images(self, images):
+    def add_unique_image(self, image):
         """
+        add image with unpredictable name
+
+        used by tag_by_labels plugin
+
+        :param image: str, name of image (e.g. "namespace/httpd:2.4")
+        :return: None
+        """
+        self._unique_images.append(ImageName.parse(image))
+
+    def add_primary_images(self, images):
+        """
+        add new primary images in bulk
+
+        used by tag_by_labels plugin
 
         :param images: list of str, list of image names
         :return: None
         """
         for image in images:
-            self.add_image(image)
+            self.add_primary_image(image)
 
 
 class Registry(object):

--- a/atomic_reactor/plugins/post_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/post_store_metadata_in_osv3.py
@@ -60,17 +60,18 @@ class StoreMetadataInOSv3Plugin(PostBuildPlugin):
         # these should be used for pulling and layering
         primary_repositories = []
         for registry in self.workflow.push_conf.all_registries:
-            for image in self.workflow.tag_conf.images:
+            for image in self.workflow.tag_conf.primary_images:
                 registry_image = image.copy()
                 registry_image.registry = registry.uri
                 primary_repositories.append(registry_image.to_str())
 
         # unique unpredictable repositories
         unique_repositories = []
-        target_image = self.workflow.builder.image.copy()
         for registry in self.workflow.push_conf.all_registries:
-            target_image.registry = registry.uri
-            unique_repositories.append(target_image.to_str())
+            for image in self.workflow.tag_conf.unique_images:
+                registry_image = image.copy()
+                registry_image.registry = registry.uri
+                unique_repositories.append(registry_image.to_str())
 
         repositories = {
             "primary": primary_repositories,

--- a/atomic_reactor/plugins/post_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/post_store_metadata_in_osv3.py
@@ -106,3 +106,4 @@ class StoreMetadataInOSv3Plugin(PostBuildPlugin):
                 "filename": os.path.basename(tar_path),
             })
         osbs.set_annotations_on_build(build_id, labels)
+        return labels

--- a/atomic_reactor/plugins/post_tag_by_labels.py
+++ b/atomic_reactor/plugins/post_tag_by_labels.py
@@ -56,4 +56,5 @@ class TagByLabelsPlugin(PostBuildPlugin):
         n = "%s:latest" % name
         n_unique = "%s:%s" % (name, unique_tag)
 
-        self.workflow.tag_conf.add_images([nvr, nv, n, n_unique])
+        self.workflow.tag_conf.add_primary_images([nvr, nv, n])
+        self.workflow.tag_conf.add_unique_image(n_unique)

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -1,0 +1,86 @@
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import print_function, unicode_literals
+
+import os
+from copy import deepcopy
+
+from flexmock import flexmock
+from osbs.api import OSBS
+from atomic_reactor.inner import DockerBuildWorkflow
+from atomic_reactor.plugin import PostBuildPluginsRunner
+from atomic_reactor.plugins.post_rpmqa import PostBuildRPMqaPlugin
+
+from atomic_reactor.plugins.post_store_metadata_in_osv3 import StoreMetadataInOSv3Plugin
+from atomic_reactor.plugins.pre_cp_dockerfile import CpDockerfilePlugin
+from atomic_reactor.plugins.pre_pyrpkg_fetch_artefacts import DistgitFetchArtefactsPlugin
+from atomic_reactor.util import ImageName, LazyGit
+from tests.constants import LOCALHOST_REGISTRY, TEST_IMAGE, INPUT_IMAGE
+
+
+class Y(object):
+    pass
+
+
+class X(object):
+    image_id = INPUT_IMAGE
+    source = Y()
+    source.dockerfile_path = None
+    source.path = None
+    base_image = ImageName(repo="qwe", tag="asd")
+    # image = ImageName.parse("test-image:unique_tag_123")
+
+
+def test_metadata_plugin(tmpdir):
+    def set_annotations_on_build(build_id, labels):
+        pass
+    new_environ = deepcopy(os.environ)
+    new_environ["BUILD"] = '{"metadata": {"name": "asd"}}'
+    flexmock(OSBS, set_annotations_on_build=set_annotations_on_build)
+    flexmock(os)
+    os.should_receive("environ").and_return(new_environ)
+
+    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, "test-image")
+
+    workflow.push_conf.add_pulp_registry("test", LOCALHOST_REGISTRY)
+    workflow.tag_conf.add_primary_image(TEST_IMAGE)
+    workflow.tag_conf.add_unique_image("namespace/image:asd123")
+
+    setattr(workflow, 'builder', X)
+    workflow.build_logs = ["a", "b"]
+    workflow.source.lg = LazyGit(None, commit="commit")
+    flexmock(workflow.source.lg)
+    workflow.source.lg.should_receive("_commit_id").and_return("commit")
+    workflow.prebuild_results = {
+        CpDockerfilePlugin.key: "dockerfile-content",
+        DistgitFetchArtefactsPlugin.key: "artefact1\nartefact2",
+    }
+    workflow.postbuild_results = {
+        PostBuildRPMqaPlugin.key: "rpm1\nrpm2",
+    }
+
+    runner = PostBuildPluginsRunner(
+        None,
+        workflow,
+        [{
+            'name': StoreMetadataInOSv3Plugin.key,
+            "args": {
+                "url": "http://example.com/"
+            }
+        }]
+    )
+    output = runner.run()
+    assert StoreMetadataInOSv3Plugin.key in output
+    labels = output[StoreMetadataInOSv3Plugin.key]
+    assert "dockerfile" in labels
+    assert "artefacts" in labels
+    assert "logs" in labels
+    assert "rpm-packages" in labels
+    assert "repositories" in labels
+    assert "commit_id" in labels

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -37,7 +37,7 @@ def test_tag_and_push_plugin(tmpdir):
 
     tasker = DockerTasker()
     workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
-    workflow.tag_conf.add_image(TEST_IMAGE)
+    workflow.tag_conf.add_primary_image(TEST_IMAGE)
     workflow.push_conf.add_docker_registry(LOCALHOST_REGISTRY, insecure=True)
     setattr(workflow, 'builder', X)
 

--- a/tests/plugins/test_tag_by_labels.py
+++ b/tests/plugins/test_tag_by_labels.py
@@ -68,8 +68,14 @@ def test_tag_by_labels_plugin(tmpdir):
     assert TagByLabelsPlugin.key in output.keys()
     assert len(workflow.tag_conf.images) == 4
     images = [i.to_str() for i in workflow.tag_conf.images]
+    primary_images = [i.to_str() for i in workflow.tag_conf.primary_images]
+    unique_images = [i.to_str() for i in workflow.tag_conf.unique_images]
     assert ("%s:%s" % (TEST_IMAGE, "unique_tag_123")) in images
     assert ("%s:%s_%s" % (TEST_IMAGE, version, release)) in images
     assert ("%s:%s" % (TEST_IMAGE, version)) in images
     assert ("%s:latest" % (TEST_IMAGE, )) in images
+    assert ("%s:%s" % (TEST_IMAGE, "unique_tag_123")) in unique_images
+    assert ("%s:%s_%s" % (TEST_IMAGE, version, release)) in primary_images
+    assert ("%s:%s" % (TEST_IMAGE, version)) in primary_images
+    assert ("%s:latest" % (TEST_IMAGE, )) in primary_images
     tasker.remove_image(image)


### PR DESCRIPTION
since we changed the names of built image in #184, we also need to
update unique repositories in build metadata, therefore this is a fixup
to #184 

Not sure if I should rename the `add_image` method. This may be confusing a bit.