### PR TITLE
Fix pulp test

### DIFF
--- a/atomic_reactor/plugins/post_push_to_pulp.py
+++ b/atomic_reactor/plugins/post_push_to_pulp.py
@@ -135,13 +135,13 @@ class PulpUploader(object):
 
 def compress(filename, ifp):
     _chunk_size = 1024*1024  # 1Mb buffer for writing file
-    with gzip.open(filename, "wb", compresslevel=6) as wfp:
-        while True:
-            data = ifp.read(_chunk_size)
-            if data == b'':
-                break
+    wfp = gzip.open(filename, "wb", compresslevel=6)
+    while True:
+        data = ifp.read(_chunk_size)
+        if data == b'':
+            break
 
-            wfp.write(data)
+        wfp.write(data)
 
 
 class PulpPushPlugin(PostBuildPlugin):

--- a/tests/plugins/test_pulp.py
+++ b/tests/plugins/test_pulp.py
@@ -58,7 +58,11 @@ def test_pulp(tmpdir):
     (flexmock(dockpulp.imgutils).should_receive('get_versions')
      .with_args(object)
      .and_return({'id': '1.6.0'}))
-    flexmock(dockpulp.imgutils).should_receive('check_repo').and_return(0)
+    (flexmock(dockpulp.imgutils).should_receive('check_repo')
+     .and_return(3)
+     .and_return(2)
+     .and_return(1)
+     .and_return(0))
     (flexmock(dockpulp.Pulp)
      .should_receive('push_tar_to_pulp')
      .with_args(object, object))
@@ -78,6 +82,12 @@ def test_pulp(tmpdir):
         'args': {
             'pulp_registry_name': 'test'
         }}])
+    with pytest.raises(Exception) as rc3:
+        runner.run()
+    with pytest.raises(Exception) as rc2:
+        runner.run()
+    with pytest.raises(Exception) as rc1:
+        runner.run()
     runner.run()
     assert PulpPushPlugin.key is not None
     images = [i.to_str() for i in workflow.postbuild_results[PulpPushPlugin.key]]

--- a/tests/plugins/test_pulp.py
+++ b/tests/plugins/test_pulp.py
@@ -18,7 +18,7 @@ from atomic_reactor.util import ImageName
 from tests.constants import INPUT_IMAGE, SOURCE, LOCALHOST_REGISTRY_HTTP
 try:
     import dockpulp
-    from dock.plugins.post_push_to_pulp import PulpPushPlugin
+    from atomic_reactor.plugins.post_push_to_pulp import PulpPushPlugin
 except (ImportError, SyntaxError):
     dockpulp = None
 
@@ -62,7 +62,9 @@ def test_pulp(tmpdir):
     (flexmock(dockpulp.Pulp)
      .should_receive('push_tar_to_pulp')
      .with_args(object, object))
-    flexmock(dockpulp.Pulp).should_receive('crane').with_args()
+    (flexmock(dockpulp.Pulp)
+     .should_receive('crane')
+     .with_args(repos=list))
     mock_docker()
 
     os.environ['SOURCE_SECRET_PATH'] = str(tmpdir)


### PR DESCRIPTION
The pulp test-case is skipped in Travis CI because of the `dockpulp` dependency. Running it locally, it fails, simply because the mocked dockpulp interface doesn't accept the argument we now pass to `dockpulp.Pulp.crane()`.

I've also added some testing for error cases.