### PR TITLE
Install dockpulp so the pulp test can run in Travis CI (#209)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
   - "pip install -r tests/requirements.txt"
   - "pip install pytest-cov coveralls"
   - "pip install git+https://github.com/DBuildService/osbs-client"
+  - "pip install git+https://github.com/release-engineering/dockpulp"
 # command to run tests
 script: "py.test -vv tests --cov atomic_reactor"
 # run in a docker container

--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -117,7 +117,7 @@ class PluginsRunner(object):
             module_name = os.path.basename(f).rsplit('.', 1)[0]
             try:
                 f_module = imp.load_source(module_name, f)
-            except (IOError, OSError, ImportError) as ex:
+            except (IOError, OSError, ImportError, SyntaxError) as ex:
                 logger.warning("can't load module '%s': %s", f, repr(ex))
                 continue
             for name in dir(f_module):

--- a/tests/plugins/test_pulp.py
+++ b/tests/plugins/test_pulp.py
@@ -19,7 +19,7 @@ from tests.constants import INPUT_IMAGE, SOURCE, LOCALHOST_REGISTRY_HTTP
 try:
     import dockpulp
     from dock.plugins.post_push_to_pulp import PulpPushPlugin
-except ImportError:
+except (ImportError, SyntaxError):
     dockpulp = None
 
 import pytest

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ ordereddict
 pytest
 six
 pytest-capturelog
+simplejson


### PR DESCRIPTION
Note that it doesn't actually run yet because of a missed `dock`/`atomic_reactor` change (#202).

The pulp test requires simplejson.

The dockpulp plugin is not valid Python 3 so this change also adds robustness against syntax errors in plugins, as well as skipping the pulp test if dockpulp cannot be imported.

Fixes #209.